### PR TITLE
Fix #1: Remove comments from tsc config

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,10 @@ if (!fs.existsSync(tsconfig_json)) {
   execSync('tsc --init');
 }
 
-const tsconfig = require(tsconfig_json);
+let tsconfig_raw = fs.readFileSync(tsconfig_json, 'utf8');
+tsconfig_raw = tsconfig_raw.replace(/\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/igm, '');
+const tsconfig = JSON.parse(tsconfig_raw);
+
 if (!tsconfig.compilerOptions || ! tsconfig.compilerOptions.lib) {
   tsconfig["compilerOptions"]["lib"] = ["dom", "es2015.promise", "es5"];
 }


### PR DESCRIPTION
- Fixes #1 

**Problem**
`tsc --init` generates a `tsconfig.json` file, however that file is loaded with comments (explaining optional params). Node's `require` tries to parse the `tsconfig` and hits those comments, and throws errors. Enter issue #1 .

**Solution**
The proposed solution here is to simply read the generated file as a string, strip the comments (via [regex](https://regexr.com/3h692)), and _then_ parse it as JSON. The `tsconfig` file is overwritten shortly after, making the comments a non-issue once `tsc-init` finishes running.